### PR TITLE
update instructions to publish a dataset

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -99,13 +99,15 @@ jobs:
             const title = `[publish] ${{ matrix.dataset }}`;
             const body = `
             ## Difference Detected Between \`Production\` and \`Staging\` in the following dataset(s)
-            ## Dataset(s)
+            ### Dataset(s)
             \`\`\`yml
             - ${{ matrix.dataset }}
             \`\`\`
-            ## Next Steps: 
-            If you have manually checked above files and they seem to be ok, comment \`[publish]\` under this issue. 
-            This would allow github actions to move staging files to production. 
+            ### Next Steps
+            If you have manually checked above files and they seem to be ok, add the \'publish\' label to this issue.
+
+            This will allow github actions to move staging files to production. 
+            
             Feel free to close this issue once it's all complete. Thanks!
             `;
 


### PR DESCRIPTION
When the process for publishing new data layers from the this repo changed to adding the `publish` label instead of commenting on the relevant issue, we never changed the instructions text.