### PR TITLE
workflow maintenance

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 0 * * *"
 jobs:
   diff:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.diff.outputs.matrix }}
       notify: ${{ steps.diff.outputs.notify }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         
       - name: Install Dependencies
         run: ./run.sh install
@@ -59,7 +59,7 @@ jobs:
         run: echo ${{ steps.diff.outputs.notify }}
 
   notify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: needs.diff.outputs.notify != '0'
     needs: [diff]
     env:
@@ -71,7 +71,7 @@ jobs:
       matrix: 
         dataset: ${{ fromJSON(needs.diff.outputs.matrix) }}
     steps:            
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v4
          
        - name: Install Dependencies
          run: ./run.sh install

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,11 +1,10 @@
 name: Production Diff Staging
+
 on:
-  push:
-    branches:
-      - patch-open-issue
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+  - cron: "0 0 * * *"
+
 jobs:
   diff:
     runs-on: ubuntu-22.04
@@ -14,132 +13,132 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: edm-publishing
-    outputs: 
+    outputs:
       matrix: ${{ steps.diff.outputs.matrix }}
       notify: ${{ steps.diff.outputs.notify }}
     steps:
-      - uses: actions/checkout@v4
-        
-      - name: Install Dependencies
-        run: ./run.sh install
-      
-      - name: Compute diff matrix
-        id: diff 
-        shell: python
-        run: |
-          import json
-          import os
-          import os
-          
-          diff=os.popen('./run.sh diff_list').readlines()
-          diff=[d.replace('\n', '') for d in diff]
-          diff_json=json.dumps(json.dumps(diff))
-          print(len(diff))
-          print(str(len(diff)))
-          os.system('''echo "notify={}" >> $GITHUB_OUTPUT'''.format(str(len(diff))))
-          os.system('''echo "matrix={}" >> $GITHUB_OUTPUT'''.format(diff_json))
-      
-      - name: notify?
-        run: |
-          echo ${{ steps.diff.outputs.notify }}
+    - uses: actions/checkout@v4
 
-      - name: Print Matrix
-        run: |
-          echo ${{ steps.diff.outputs.matrix }}
-      
-      - name: test notify
-        run: echo ${{ steps.diff.outputs.notify }}
-      
-      - name: test notify
-        if: steps.diff.outputs.notify != '0'
-        run: echo ${{ steps.diff.outputs.notify }}
-      
-      - name: test notify
-        if: steps.diff.outputs.notify != 0
-        run: echo ${{ steps.diff.outputs.notify }}
+    - name: Install Dependencies
+      run: ./run.sh install
+
+    - name: Compute diff matrix
+      id: diff
+      shell: python
+      run: |
+        import json
+        import os
+        import os
+
+        diff=os.popen('./run.sh diff_list').readlines()
+        diff=[d.replace('\n', '') for d in diff]
+        diff_json=json.dumps(json.dumps(diff))
+        print(len(diff))
+        print(str(len(diff)))
+        os.system('''echo "notify={}" >> $GITHUB_OUTPUT'''.format(str(len(diff))))
+        os.system('''echo "matrix={}" >> $GITHUB_OUTPUT'''.format(diff_json))
+
+    - name: notify?
+      run: |
+        echo ${{ steps.diff.outputs.notify }}
+
+    - name: Print Matrix
+      run: |
+        echo ${{ steps.diff.outputs.matrix }}
+
+    - name: test notify
+      run: echo ${{ steps.diff.outputs.notify }}
+
+    - name: test notify
+      if: steps.diff.outputs.notify != '0'
+      run: echo ${{ steps.diff.outputs.notify }}
+
+    - name: test notify
+      if: steps.diff.outputs.notify != 0
+      run: echo ${{ steps.diff.outputs.notify }}
 
   notify:
     runs-on: ubuntu-22.04
     if: needs.diff.outputs.notify != '0'
-    needs: [diff]
+    needs: [ diff ]
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: edm-publishing
     strategy:
-      matrix: 
+      matrix:
         dataset: ${{ fromJSON(needs.diff.outputs.matrix) }}
-    steps:            
-       - uses: actions/checkout@v4
-         
-       - name: Install Dependencies
-         run: ./run.sh install
-       
-       - name: Random Sleep
-         run:  sleep $[ ( $RANDOM % 10 )  + 1 ]s
+    steps:
+    - uses: actions/checkout@v4
 
-       - name: Get Category
-         id: category
-         run: |
-          category=$(cat metadata.json |  jq -r '.[] | select( .name | contains("${{ matrix.dataset }}"))' | jq -r '.category')
-          echo "category=$category" >> $GITHUB_OUTPUT
+    - name: Install Dependencies
+      run: ./run.sh install
 
-       - uses: actions/github-script@v3
-         name: Create Issue to Publish (if it doesn't exist)
-         with: 
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            let category;
-            if ('${{ steps.category.outputs.category }}' === '') {
-              category = '🚕 Other'
-            } else {
-              category = '${{ steps.category.outputs.category }}'
-            }
-            const title = `[publish] ${{ matrix.dataset }}`;
-            const body = `
-            ## Difference Detected Between \`Production\` and \`Staging\` in the following dataset(s)
-            ### Dataset(s)
-            \`\`\`yml
-            - ${{ matrix.dataset }}
-            \`\`\`
-            ### Next Steps
-            If you have manually checked above files and they seem to be ok, add the \'publish\' label to this issue.
+    - name: Random Sleep
+      run: sleep $[ ( $RANDOM % 10 )  + 1 ]s
 
-            This will allow github actions to move staging files to production. 
-            
-            Feel free to close this issue once it's all complete. Thanks!
-            `;
+    - name: Get Category
+      id: category
+      run: |
+        category=$(cat metadata.json |  jq -r '.[] | select( .name | contains("${{ matrix.dataset }}"))' | jq -r '.category')
+        echo "category=$category" >> $GITHUB_OUTPUT
 
-            const issues = await github.issues.listForRepo({
+    - uses: actions/github-script@v3
+      name: Create Issue to Publish (if it doesn't exist)
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          let category;
+          if ('${{ steps.category.outputs.category }}' === '') {
+            category = '🚕 Other'
+          } else {
+            category = '${{ steps.category.outputs.category }}'
+          }
+          const title = `[publish] ${{ matrix.dataset }}`;
+          const body = `
+          ## Difference Detected Between \`Production\` and \`Staging\` in the following dataset(s)
+          ### Dataset(s)
+          \`\`\`yml
+          - ${{ matrix.dataset }}
+          \`\`\`
+          ### Next Steps
+          If you have manually checked above files and they seem to be ok, add the \'publish\' label to this issue.
+
+          This will allow github actions to move staging files to production. 
+
+          Feel free to close this issue once it's all complete. Thanks!
+          `;
+
+          const issues = await github.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open'
+          });
+          const filtered = issues.data.filter(issue => issue.title === title)
+
+          if (filtered.length > 0) {
+            console.log('Issue Already Exists')
+          } else {
+            github.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open'
+              title: title,
+              body: body,
+              assignees: ["ileoyu", "OmarOrtiz1"],
+              labels: ['staging', category]
             });
-            const filtered = issues.data.filter(issue => issue.title === title)
-            
-            if (filtered.length > 0) {
-              console.log('Issue Already Exists')
-            } else {
-              github.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                assignees: ["ileoyu", "OmarOrtiz1"],
-                labels: ['staging', category]
-              });
-            }
+          }
 
   keepalive-job:
     name: Keepalive Workflow
     if: ${{ always() }}
-    needs: [ notify ] 
+    needs: [ notify ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2
-        with:
-          use_api: false
+    - uses: actions/checkout@v4
+    - uses: gautamkrishnar/keepalive-workflow@v2
+      with:
+        use_api: false

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -36,8 +36,8 @@ jobs:
           diff_json=json.dumps(json.dumps(diff))
           print(len(diff))
           print(str(len(diff)))
-          os.system('''echo "::set-output name=notify::{}"'''.format(str(len(diff))))
-          os.system('''echo "::set-output name=matrix::{}"'''.format(diff_json))
+          os.system('''echo "notify={}" >> $GITHUB_OUTPUT'''.format(str(len(diff))))
+          os.system('''echo "matrix={}" >> $GITHUB_OUTPUT'''.format(diff_json))
       
       - name: notify?
         run: |
@@ -83,7 +83,7 @@ jobs:
          id: category
          run: |
           category=$(cat metadata.json |  jq -r '.[] | select( .name | contains("${{ matrix.dataset }}"))' | jq -r '.category')
-          echo "::set-output name=category::$category"
+          echo "category=$category" >> $GITHUB_OUTPUT
 
        - uses: actions/github-script@v3
          name: Create Issue to Publish (if it doesn't exist)

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -130,3 +130,16 @@ jobs:
                 labels: ['staging', category]
               });
             }
+
+  keepalive-job:
+    name: Keepalive Workflow
+    if: ${{ always() }}
+    needs: [ notify ] 
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2
+        with:
+          use_api: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >- 
       ( 
         contains(github.event.issue.title, '[publish]') && 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           start = splited.index("```yml")+1
           end = splited.index("```")
           datasets=' '.join([i[2:] for i in splited[start:end]])
-          os.system('echo "::set-output name=datasets::{0}"'.format(datasets))
+          os.system('echo "datasets={0}" >> $GITHUB_OUTPUT'.format(datasets))
                   
       - name: test output
         run: echo "${{ steps.parsing.outputs.datasets }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,62 +1,62 @@
 name: Staging -> Production
+
 on:
   issues:
-    types: [labeled]
+    types: [ labeled ]
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
-    if: >- 
+    if: >-
       ( 
         contains(github.event.issue.title, '[publish]') && 
         contains(github.event.comment.body, '[publish]') && (
           github.event.comment.user.login == 'dhochbaum-dcp'||
           github.event.comment.user.login == 'jpiacentinidcp'
         )
-      ) || 
-      contains(github.event.issue.labels.*.name, 'publish')
+      ) ||  contains(github.event.issue.labels.*.name, 'publish')
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: edm-publishing
-    steps:      
-      - uses: actions/checkout@v2
-        
-      - name: Install Dependencies
-        run: ./run.sh install
-      
-      - name: Parse dataset names
-        shell: python
-        id: parsing
-        run: |
-          import os
-          
-          body = """${{ github.event.issue.body }}"""
-          splited = body.split('\n')
-          start = splited.index("```yml")+1
-          end = splited.index("```")
-          datasets=' '.join([i[2:] for i in splited[start:end]])
-          os.system('echo "datasets={0}" >> $GITHUB_OUTPUT'.format(datasets))
-                  
-      - name: test output
-        run: echo "${{ steps.parsing.outputs.datasets }}"
-          
-      - name: Run recipe
-        run: |
-          for i in ${{ steps.parsing.outputs.datasets }}
-          do
-            ./run.sh publish $i
-          done
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Dependencies
+      run: ./run.sh install
+
+    - name: Parse dataset names
+      shell: python
+      id: parsing
+      run: |+
+        import os
+
+        body = """${{ github.event.issue.body }}"""
+        splited = body.split('\n')
+        start = splited.index("```yml")+1
+        end = splited.index("```")
+        datasets=' '.join([i[2:] for i in splited[start:end]])
+        os.system('echo "datasets={0}" >> $GITHUB_OUTPUT'.format(datasets))
                 
-      - name: Success Message
-        if: success()
-        uses:  peter-evans/close-issue@v1
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          comment: |
-            ## Publish Complete!
+    - name: test output
+      run: echo "${{ steps.parsing.outputs.datasets }}"
+
+    - name: Run recipe
+      run: |+
+        for i in ${{ steps.parsing.outputs.datasets }}
+        do
+          ./run.sh publish $i
+        done
             
-            ${{ steps.parsing.outputs.datasets }}
-            
-            *Published By: @${{ github.actor }}* for more details, check [here](https://github.com/NYCPlanning/edm-data-operations/actions/runs/${{ github.run_id }})
+    - name: Success Message
+      if: success()
+      uses: peter-evans/close-issue@v1
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        comment: |
+          ## Publish Complete!
+
+          ${{ steps.parsing.outputs.datasets }}
+
+          *Published By: @${{ github.actor }}* for more details, check [here](https://github.com/NYCPlanning/edm-data-operations/actions/runs/${{ github.run_id }})

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/stale@v3
       with:


### PR DESCRIPTION
Commit by commit will be way easier because I reformatted the yml files!

Commit 1 is the main one - this adds a dummy commit to the repo if there has been no activity in 45+ days. This is needed to prevent github workflows from becoming automatically disabled

Also saw we had [some warnings](https://github.com/NYCPlanning/edm-data-operations/actions/runs/13662013853), so did a little maintenance

[Successful action](https://github.com/NYCPlanning/edm-data-operations/actions/runs/13663610645/job/38200099845) with printing out (empty) results for checking diffs (making sure that the warnings tweaks still work)

Not quite sure of the best way to test the keepalive functionality... I sort of think we just try it out and see if it works