### PR TITLE
remove keepalive workflow

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -130,16 +130,3 @@ jobs:
               labels: ['staging', category]
             });
           }
-
-  keepalive-job:
-    name: Keepalive Workflow
-    if: ${{ always() }}
-    needs: [ notify ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v4
-    - uses: gautamkrishnar/keepalive-workflow@v2
-      with:
-        use_api: false


### PR DESCRIPTION
keepalive workflow apparently violated gh's terms of service and has been removed.

I'll poke around to see if there are other sensible solutions to keep the scheduled actions from stopping