### PR TITLE
Make published files public-read

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,10 @@
 name: Staging -> Production
 
-on:
-  issues:
-    types: [ labeled ]
+on: workflow_dispatch
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
-    if: >-
-      ( 
-        contains(github.event.issue.title, '[publish]') && 
-        contains(github.event.comment.body, '[publish]') && (
-          github.event.comment.user.login == 'dhochbaum-dcp'||
-          github.event.comment.user.login == 'jpiacentinidcp'
-        )
-      ) ||  contains(github.event.issue.labels.*.name, 'publish')
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
@@ -26,29 +16,9 @@ jobs:
     - name: Install Dependencies
       run: ./run.sh install
 
-    - name: Parse dataset names
-      shell: python
-      id: parsing
-      run: |+
-        import os
-
-        body = """${{ github.event.issue.body }}"""
-        splited = body.split('\n')
-        start = splited.index("```yml")+1
-        end = splited.index("```")
-        datasets=' '.join([i[2:] for i in splited[start:end]])
-        os.system('echo "datasets={0}" >> $GITHUB_OUTPUT'.format(datasets))
-                
-    - name: test output
-      run: echo "${{ steps.parsing.outputs.datasets }}"
-
     - name: Run recipe
-      run: |+
-        for i in ${{ steps.parsing.outputs.datasets }}
-        do
-          ./run.sh publish $i
-        done
-            
+      run: ./run.sh publish dcp_address_points
+
     - name: Success Message
       if: success()
       uses: peter-evans/close-issue@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,20 @@
 name: Staging -> Production
 
-on: workflow_dispatch
+on:
+  issues:
+    types: [ labeled ]
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    if: >-
+      ( 
+        contains(github.event.issue.title, '[publish]') && 
+        contains(github.event.comment.body, '[publish]') && (
+          github.event.comment.user.login == 'dhochbaum-dcp'||
+          github.event.comment.user.login == 'jpiacentinidcp'
+        )
+      ) ||  contains(github.event.issue.labels.*.name, 'publish')
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
@@ -16,9 +26,29 @@ jobs:
     - name: Install Dependencies
       run: ./run.sh install
 
-    - name: Run recipe
-      run: ./run.sh publish dcp_address_points
+    - name: Parse dataset names
+      shell: python
+      id: parsing
+      run: |+
+        import os
 
+        body = """${{ github.event.issue.body }}"""
+        splited = body.split('\n')
+        start = splited.index("```yml")+1
+        end = splited.index("```")
+        datasets=' '.join([i[2:] for i in splited[start:end]])
+        os.system('echo "datasets={0}" >> $GITHUB_OUTPUT'.format(datasets))
+                
+    - name: test output
+      run: echo "${{ steps.parsing.outputs.datasets }}"
+
+    - name: Run recipe
+      run: |+
+        for i in ${{ steps.parsing.outputs.datasets }}
+        do
+          ./run.sh publish $i
+        done
+            
     - name: Success Message
       if: success()
       uses: peter-evans/close-issue@v1

--- a/run.sh
+++ b/run.sh
@@ -45,7 +45,7 @@ function publish {
         publishing  $STAGING_PATH
         to          $PUBLISH_PATH
     \033[0;31m"
-    mc cp --recursive $STAGING_PATH $PUBLISH_PATH
+    mc cp --attr x-amz-acl=public-read --recursive $STAGING_PATH $PUBLISH_PATH
 }
 
 function show {


### PR DESCRIPTION
@fvankrieken Had to hack away at the action, but I can now confirm from [this](https://github.com/NYCPlanning/edm-data-operations/actions/runs/15933518666/job/44948034411) run that the outputs are public. (The run failed due to the last step, but the publish step ran just fine).