### PR TITLE
fix minio

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -30,11 +30,12 @@ jobs:
         import os
         import os
 
+        dataset_names=os.popen('./run.sh list').readlines()
+        print("dataset_names: {}".format(dataset_names))
         diff=os.popen('./run.sh diff_list').readlines()
         diff=[d.replace('\n', '') for d in diff]
         diff_json=json.dumps(json.dumps(diff))
-        print(len(diff))
-        print(str(len(diff)))
+        print("diff: {}".format(diff))
         os.system('''echo "notify={}" >> $GITHUB_OUTPUT'''.format(str(len(diff))))
         os.system('''echo "matrix={}" >> $GITHUB_OUTPUT'''.format(diff_json))
 

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,12 @@ function set_env {
 set_env .env
 BUCKET=$AWS_S3_BUCKET
 
+function set_error_traps {
+  # Exit when any command fails
+  set -e
+}
+set_error_traps
+
 # Setup: Download and Install minio
 function install {
     # Use -o to force the downloaded binary filename

--- a/run.sh
+++ b/run.sh
@@ -15,8 +15,8 @@ BUCKET=$AWS_S3_BUCKET
 
 # Setup: Download and Install minio
 function install {
-    curl -O https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-04-19T19-17-53Z
-    mv mc.RELEASE.2020-04-19T19-17-53Z mc
+    # Use -o to force the downloaded binary filename
+    curl -fL https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-04-19T19-17-53Z -o mc
     chmod +x mc
     sudo mv ./mc /usr/bin
     mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4


### PR DESCRIPTION
the filename of the downloaded minio client changed so the github action was failing to install what it needs to read files in DO's S3 storage

the action also wasn't setup to explicitly fail when bash functions error

[successful run](https://github.com/NYCPlanning/edm-data-operations/actions/runs/26919383210)

[new error handling working](https://github.com/NYCPlanning/edm-data-operations/actions/runs/26909244663/job/79382507630) (used a temporary commit to force a failure that has now been dropped)

