### PR TITLE
Fix diff_list

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -76,21 +76,23 @@ function diff {
     VERSION=${2:-staging}
     STAGING_PATH=spaces/$BUCKET/datasets/$1/$VERSION
     PUBLISH_PATH=spaces/$BUCKET/datasets/$1/production
-    for INFO in $(mc ls --recursive --json $STAGING_PATH)
+    status=false
+    status_verbose='false'
+    while IFS= read -r INFO
     do
         KEY=$(echo $INFO | jq -r '.key')
-        stg_etag=$(mc stat --json $STAGING_PATH/$KEY | jq -r '.etag')            
+        stg_etag=$(mc stat --json $STAGING_PATH/$KEY | jq -r '.etag')
         prod_etag=$(mc stat --json $PUBLISH_PATH/$KEY | jq -r '.etag')
-        if [ $stg_etag != $prod_etag ]
-        then 
+        if [ "$stg_etag" != "$prod_etag" ]
+        then
             status=true
             status_verbose='true'
             break
-        else 
+        else
             status=false
             status_verbose='false'
         fi
-    done
+    done < <(mc ls --recursive --json $STAGING_PATH)
 }
 
 


### PR DESCRIPTION
### The Problem
Basically, diff_list is iterating through 10 datasets, then failing on 11. jq has trouble parsing the mc response, and now that we set error traps, the script exits

  Looking at diff_list (run.sh:96-105):
```bash
  function diff_list {
      for key in $(list)
      do
          k=${key%"/"}
          diff "" "$k"
          if $status;
          then echo "$k"
          fi
      done
  }
```
  Here's the execution flow:

  1. diff_list iterates through ALL datasets alphabetically
  2. For each dataset, it calls diff "" "$k" to check for differences
  3. If diff succeeds and finds differences, it echoes the dataset name to stdout
  4. When it eventually hits a dataset where jq fails (due to the malformed JSON), set -e causes the script to exit immediately
  5. But all the echo "$k" calls that happened before the failure already wrote to stdout

### The Solution
We handle multiline JSON